### PR TITLE
Alternative Approach: Extension of the existing content security policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ of the [Privacy Community Group](https://privacycg.github.io/).
 - [Kaustubha Govind](https://github.com/krgovind), Google
 - [Harneet Sidhana](https://github.com/HarneetSidhana), Microsoft 
 - [Johann Hofmann](https://github.com/johannhof), Google
+- [Damian Lion Maring](https://github.com/DamianLion), SAP
 
 ## Participate
 - https://github.com/privacycg/first-party-sets/issues
@@ -466,6 +467,17 @@ This origin-defined approach has additional complications to resolve:
 
 These complexities are likely solvable while keeping most of this design, should browsers believe
 this is worthwhile.
+
+## Extension of the existing content security policy header
+
+Mesures already implimented with the [content-security-policy](https://w3c.github.io/webappsec-csp/) allow applications to precisely define which resources shall / can be loaded or even which [describe capabilties of the script executed](https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval) on said webpages. With the csp directive of [`frame-src`](https://w3c.github.io/webappsec-csp/#directive-frame-src) we define which resources shall be allowed to be embedded as an iFrame by the hosting application. The [`frame-ancestors`](https://w3c.github.io/webappsec-csp/#directive-frame-ancestors) directive on the other hand defines which web applications are allowed to frame the hosted website
+
+Together both directives already form a bond and can set a certain trust. With the extension of of the csp a special parameter like `trusted-first-party:` or `owner` and `member` parameters could be introduced. These could either act standalone or as suffix / prefix parameters to the existing source-list. 
+
+Embedding scenarious would benefits as they could counter-act the removal of third-party-cookie support with minimal effort. The existing csp format allows webistes to define certain wildcards in order to have flexibility with their first-party-set
+
+However this alternative approach is mostly focused on iFraming scenarios. 
+
 
 # Security and Privacy Considerations
 


### PR DESCRIPTION
Hey Everybody,

I really appreciate the work that has already been done towards the direction of mitigating upcoming damage dealt by the removal of third-party-cookie support. Internally, I was working a lot on concepts and ideas how we could solve the inevitable. While reading this document, I had the gut feeling there would be a "simple" solution to this issue that I really would like to explore together with you. In principle I would like to explore with we can extend the CSP Header for `frame-ancestors` and `frame-src`. I added my proposal into the section *alternative design* and would like to discuss it with you. I do also have the feeling I am definitely not the first one to bring this up, and might just missed the part where such a manoeuvre is simply impossible. 

We have multiple occasions (`sap.com`, `cloud.sap`, `ondemand.com`, `ariba.com`, `sap.com`, `fieldglass.com`, `qualtrics.com`...) where we do have touchpoints to this topic, often we talk about embedding and cross integration scenarios. Additionally I would like to bring up the topic of customer owned domains and integration of our domains into their landscape.

Therefore, will keep an eye on upcoming changes and how and if we can involve and contribute ourselves. 

Upfront I would like to thank you for your input and feedback