### PR TITLE
Update rSAFor integration

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -210,6 +210,11 @@ A given [=environment settings object=] |settings| <dfn>is same-party with its t
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
 1. Return whether |embeddedSite| is [=eligible for same-party membership when embedded within=] |topLevelSite|.
 
+A given [=environment settings object=] |settings| and [=/origin=] |origin| <dfn>are same-party in an embedding context</dfn>, if the following steps return true:
+1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment/top-level origin=].
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |origin|.
+1. Return whether |embeddedSite| is [=eligible for same-party membership when embedded within=] |topLevelSite|.
+
 <h2 id="storage-access-integration">Integration with the Storage Access API</h2>
 
 Modify {{Document/requestStorageAccess()}} to insert the following steps before step 13.5 (i.e. before [=requesting permission to use=]):
@@ -217,10 +222,10 @@ Modify {{Document/requestStorageAccess()}} to insert the following steps before 
 1. Let |settings| be <var ignore>doc</var>'s [=relevant settings object=].
 1. If |settings| [=is same-party with its top-level embedder=], the user agent may run <var ignore>process permission state</var> with [=permission/granted=] and abort the remaining steps.
 
-Modify {{Document/requestStorageAccessForOrigin(origin)}} to insert the following steps before step 13.8 (i.e. before [=requesting permission to use=]):
+Modify {{Document/requestStorageAccessForOrigin(requestedOrigin)}} to insert the following steps before step 13.8 (i.e. before [=requesting permission to use=]):
 
 1. Let |settings| be <var ignore>doc</var>'s [=relevant settings object=].
-1. If |settings| [=is same-party with its top-level embedder=], the user agent may [=queue a global task=] on the [=permissions task source=] given <var ignore>global</var> to [=resolve=] <var ignore>p</var> and abort the remaining steps.
+1. If |settings| and <var ignore>requestedOrigin</var> [=are same-party in an embedding context=], the user agent may [=queue a global task=] on the [=permissions task source=] given <var ignore>global</var> to [=resolve=] <var ignore>p</var> and abort the remaining steps.
 
 <h2 id="handling-changes">Handling first-party set changes</h2>
 


### PR DESCRIPTION
This change updates the parameter name to requestedOrigin. It also defines a mechanism for determining whether a document's settings object is same-party with an arbitrary origin.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mreichhoff/first-party-sets/pull/137.html" title="Last updated on Feb 21, 2023, 4:33 PM UTC (718ad24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/first-party-sets/137/c7ac7c0...mreichhoff:718ad24.html" title="Last updated on Feb 21, 2023, 4:33 PM UTC (718ad24)">Diff</a>